### PR TITLE
fix: add `build(deps)` rule, remove version output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "dependencies": {
         "@semantic-release/changelog": "^6.0.0",
         "@semantic-release/commit-analyzer": "^9.0.1",
-        "@semantic-release/exec": "^6.0.1",
         "@semantic-release/git": "^10.0.0",
         "@semantic-release/github": "^8.0.1",
         "@semantic-release/npm": "^8.0.3",
@@ -246,25 +245,6 @@
       "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/@semantic-release/exec": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.2.tgz",
-      "integrity": "sha512-ciaqJTHB1TFtU6C78xrgmoNI9UyfheR9+Bk6Ico7CJ7+ADOEAvUrPBKvz64UCfoWlg+SlKGTVGbFnA509wRUVw==",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "parse-json": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
       }
     },
     "node_modules/@semantic-release/git": {
@@ -6034,19 +6014,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
       "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="
-    },
-    "@semantic-release/exec": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.2.tgz",
-      "integrity": "sha512-ciaqJTHB1TFtU6C78xrgmoNI9UyfheR9+Bk6Ico7CJ7+ADOEAvUrPBKvz64UCfoWlg+SlKGTVGbFnA509wRUVw==",
-      "requires": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "parse-json": "^5.0.0"
-      }
     },
     "@semantic-release/git": {
       "version": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/commit-analyzer": "^9.0.1",
-    "@semantic-release/exec": "^6.0.1",
     "@semantic-release/git": "^10.0.0",
     "@semantic-release/github": "^8.0.1",
     "@semantic-release/npm": "^8.0.3",

--- a/release.config.js
+++ b/release.config.js
@@ -4,6 +4,7 @@ const commitAnalyzerOptions = {
     { type: 'breaking', release: 'major' },
     { type: 'refactor', release: 'patch' },
     { type: 'config', release: 'patch' },
+    { type: 'build', scope: 'deps', release: false },
     { scope: 'chore', release: false },
     { scope: 'no-release', release: false },
     { scope: 'test', release: false },
@@ -30,6 +31,8 @@ const releaseNotesGeneratorOptions = {
         commit.type = 'Config';
       } else if (commit.type === 'test') {
         commit.type = 'Tests';
+      } else if (commit.type === 'build(deps)') {
+        commit.type = 'Dependencies';
       } else if (commit.type === 'docs') {
         commit.type = 'Documentation';
       } else if (commit.type === 'no-release') {
@@ -44,10 +47,6 @@ const releaseNotesGeneratorOptions = {
   },
 };
 
-const execCommands = {
-  verifyReleaseCmd: 'echo ${nextRelease.version} > version',
-};
-
 module.exports = {
   plugins: [
     // analyze commits with conventional-changelog
@@ -59,8 +58,6 @@ module.exports = {
     '@semantic-release/git',
     // creating a git tag
     '@semantic-release/github',
-    // run events commands
-    ['@semantic-release/exec', execCommands],
   ],
   branches: ["main", "master", "develop"]
 };

--- a/release.config.js
+++ b/release.config.js
@@ -4,7 +4,7 @@ const commitAnalyzerOptions = {
     { type: 'breaking', release: 'major' },
     { type: 'refactor', release: 'patch' },
     { type: 'config', release: 'patch' },
-    { type: 'build', scope: 'deps', release: false },
+    { scope: 'deps', release: false },
     { scope: 'chore', release: false },
     { scope: 'no-release', release: false },
     { scope: 'test', release: false },
@@ -31,7 +31,7 @@ const releaseNotesGeneratorOptions = {
         commit.type = 'Config';
       } else if (commit.type === 'test') {
         commit.type = 'Tests';
-      } else if (commit.type === 'build(deps)') {
+      } else if (commit.type === 'deps') {
         commit.type = 'Dependencies';
       } else if (commit.type === 'docs') {
         commit.type = 'Documentation';


### PR DESCRIPTION
- Adds a `build(deps)` prefix rule to play well with Dependabot
- Adds a release note heading for this new prefix rule
- Removes `execCommands` module