### PR TITLE
chore(CODEOWNERS): add CODEOWNERS for this repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @HGData/development-operations


### PR DESCRIPTION
@sbchapin I would like to suggest we add a `CODEOWNERS` here with the DevOps team specified.